### PR TITLE
whoami: Fix whoami help description to conform to the travis

### DIFF
--- a/contrib/completion/zsh/_goravis
+++ b/contrib/completion/zsh/_goravis
@@ -23,7 +23,7 @@ _goravis() {
   'token:outputs the secret API token'
   'version:outputs the client version'
   'whatsup:lists most recent builds'
-  'whoami:displays accounts and their subscription status'
+  'whoami:outputs the current user'
   )
 
   __repo=(

--- a/whoami.go
+++ b/whoami.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alecthomas/kingpin"
 )
 
-var whoamiCommand = kingpin.Command("whoami", "displays accounts and their subscription status").Action(func(ctx *kingpin.ParseContext) error {
+var whoamiCommand = kingpin.Command("whoami", "outputs the current user").Action(func(ctx *kingpin.ParseContext) error {
 	err := auth()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix whoami help description.
`displays accounts and their subscription status` for `accounts` command, actually `outputs the current user`.
