### PR TITLE
config: Support $TRAVIS_CONFIG_PATH environment variable

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,16 +33,27 @@ type Config struct {
 	Repos             map[string]*Repo     `yaml:"repos"`
 }
 
+const configYml = "config.yml"
+
 func newConfig() *Config {
-	home := os.Getenv("HOME")
-	if home == "" && runtime.GOOS == "windows" {
-		home = os.Getenv("USERPROFILE")
-	}
 	c := &Config{
 		EndPoints: make(map[string]*EndPoint),
 		Repos:     make(map[string]*Repo),
 	}
-	c.path = filepath.Join(home, ".travis", "config.yml")
+
+	if configPath := os.Getenv("TRAVIS_CONFIG_PATH"); configPath != "" {
+		path := filepath.Join(configPath, configYml)
+		if _, err := os.Stat(path); err == nil {
+			c.path = path
+			return c
+		}
+	}
+
+	home := os.Getenv("HOME")
+	if home == "" && runtime.GOOS == "windows" {
+		home = os.Getenv("USERPROFILE")
+	}
+	c.path = filepath.Join(home, ".travis", configYml)
 	os.MkdirAll(filepath.Dir(c.path), 0700)
 	return c
 }

--- a/login.go
+++ b/login.go
@@ -13,6 +13,10 @@ import (
 )
 
 var loginCommand = kingpin.Command("login", "authenticates against the API and stores the token").Action(func(ctx *kingpin.ParseContext) error {
+	if token() != "" {
+		return nil
+	}
+
 	if err := tryHubConfig(); err == nil {
 		return nil
 	}


### PR DESCRIPTION
Check `$TRAVIS_CONFIG_PATH` env before the `$HOME` directory.
Also check exists `$TRAVIS_CONFIG_PATH/.travis.yml` file.
It may useful for users already have travis config file.

Successful `login` and `token` commands, but I am not confident of whether it is correct, please review it.

ref: https://github.com/travis-ci/travis.rb#environment-variables